### PR TITLE
Remove textfill method on updateComputerCost

### DIFF
--- a/ExpansionPack/source/CC_AddOn.js
+++ b/ExpansionPack/source/CC_AddOn.js
@@ -2956,10 +2956,10 @@ var CusCom = {};
 		qACost *= 1E6;
 		cost += qACost;
 		var costElement = modalContent.find(".windowCostLabel");
-		costElement.empty().append($("<span>{0}</span>".format("Cost: {0}".localize().format(UI.getShortNumberString(cost))))).textfill({
-			maxFontPixels : 20,
-			maxHeightPts : 37
-		});
+		costElement.empty().append($("<span>{0}</span>".format("Cost: {0}".localize().format(UI.getShortNumberString(cost)))));//.textfill({
+		//	maxFontPixels : 20,
+		//	maxHeightPts : 37
+		//});
 		return cost
 	};
 	function costSliderEase(t, b, c, d) {


### PR DESCRIPTION
Commented out the textfill portion on lines 2959-2962. This was causing a crash on my system and could not discover a better alternative to using textfill without adding in the textfill implementation to the file. This is a "quick and dirty" solution with minimal code changes to the following (now closed issue) by me:
https://github.com/DzjengisKhan/GDT-Expansion-Pack/issues/15 - Unhandled Exception
